### PR TITLE
fix(ci): fixes #98 by pinning poetry version

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install Poetry
         shell: bash
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The `poetry install --sync` command is only deprecated in `2.0.0`. A migration to version 2 needs more work and so for now downgrading and pinning ci is the solution