### PR TITLE
fix(poetry): virtualize poetry and project dependencies fix #100

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,24 +7,28 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    pipx \
     libpq5 \
     dos2unix \
     curl \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
-ENV POETRY_VERSION=1.8.4
-RUN pip install --no-cache-dir "poetry==$POETRY_VERSION"
+# Ensure pipx apps are available in the PATH
+# `pipx ensurepath` does the same but for whatever reason does not work here
+ENV PATH="/root/.local/bin:$PATH"
+
+ENV POETRY_VERSION=1.8.5
+RUN pipx install --python "$(which python)" "poetry==$POETRY_VERSION"
 
 WORKDIR /app
 
 COPY pyproject.toml poetry.lock ./
 
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root --only main
+RUN poetry install --no-interaction --no-ansi --no-root --only main
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python manage.py health_check || exit 1
+    CMD poetry run python manage.py health_check || exit 1
 
 # ===========================
 # Development Stage
@@ -61,11 +65,11 @@ WORKDIR /home/appuser/app
 
 COPY --chown=appuser . .
 
-RUN python manage.py collectstatic --noinput
+RUN poetry run python manage.py collectstatic --noinput
 
 USER appuser
 
-RUN chmod +x entrypoint.sh
+RUN dos2unix entrypoint.sh && chmod +x entrypoint.sh
 
 ENTRYPOINT ["./entrypoint.sh"]
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-python manage.py migrate --noinput
-python manage.py createsuperuser --noinput --username root || true
-exec "$@"
+poetry run python manage.py migrate --noinput
+poetry run python manage.py createsuperuser --noinput --username root || true
+exec poetry run "$@"


### PR DESCRIPTION
Citing the issue:

> From the poetry docs:
> 
> > Poetry should always be installed in a dedicated virtual environment to isolate it from the rest of your system. It should in no case be installed in the environment of the project that is to be managed by Poetry. This ensures that Poetry’s own dependencies will not be accidentally upgraded or uninstalled. (Each of the following installation methods ensures that Poetry is installed into an isolated environment.) In addition, the isolated virtual environment in which poetry is installed should not be activated for running poetry commands
> 
> Poetry docs recommend installing poetry via pipx to isolate it from the system dependencies.
> 
> There is also no reason not to create a venv. The performance/size gain is minimal while enabling poetry's venv feature potentially prevents the project's dependencies clashing with poetry's deps.