### PR TITLE
fix(code-scan): add permissions to CI workflow

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,5 +1,8 @@
 name: CI Checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Permissions had not been set on the CI workflow and recently enable code scans pointed that out

fixes #103