### PR TITLE
chore(dependabot): group modular tooling like jest and stylelint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,16 @@ updates:
           - "@typescript-eslint/*"
           - "eslint"
           - "eslint-*"
+      stylelint:
+        patterns:
+          - "stylelint"
+          - "stylelint-*"
+          - "@csstools/stylelint-formatter-github"
+      jest:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "@types/jest"
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
PR's: #110 #112 should have been updated together as the new stylelint config version requires new rules introduced by stylelint. This PR rectifies the fact they have not been grouped together and proactively groups jest tooling