### PR TITLE
fix(hadolint): fix hadolint false positive

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,9 +17,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Ensure pipx apps are available in the PATH
 # `pipx ensurepath` does the same but for whatever reason does not work here
 ENV PATH="/root/.local/bin:$PATH"
+ENV PIPX_DEFAULT_PYTHON="/usr/local/bin/python"
 
 ENV POETRY_VERSION=1.8.5
-RUN pipx install --python "$(which python)" "poetry==$POETRY_VERSION"
+RUN pipx install "poetry==$POETRY_VERSION"
 
 WORKDIR /app
 


### PR DESCRIPTION
hadolint triggers the DL3013 rule when using --python option with pipx despite it being satisfied.

This pr modifies that statement to use an env var over the option to avoid this false positive